### PR TITLE
Update grafonnet dependency to latest master 3264a8a

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "grafonnet"
                 }
             },
-            "version": "11022f5e920ac1ea960556193e3f0ab57d70d7c5"
+            "version": "3264a8ab6efa23d55da45ea3a3d3b39e86696c76"
         }
     ]
 }

--- a/vendor/grafonnet/dashboard.libsonnet
+++ b/vendor/grafonnet/dashboard.libsonnet
@@ -112,7 +112,7 @@ local timepickerlib = import 'timepicker.libsonnet';
         _nextPanel: nextPanel + n,
         panels+::: _panels,
       },
-    addPanel(panel, gridPos):: self + self.addPanels([panel { gridPos: gridPos }]),
+    addPanel(panel, gridPos):: self.addPanels([panel { gridPos: gridPos }]),
     addRows(rows):: std.foldl(function(d, row) d.addRow(row), rows, self),
     addLink(link):: self {
       links+: [link],

--- a/vendor/grafonnet/grafana.libsonnet
+++ b/vendor/grafonnet/grafana.libsonnet
@@ -9,6 +9,7 @@
   graphPanel:: import 'graph_panel.libsonnet',
   tablePanel:: import 'table_panel.libsonnet',
   singlestat:: import 'singlestat.libsonnet',
+  pieChartPanel:: import 'pie_chart_panel.libsonnet',
   influxdb:: import 'influxdb.libsonnet',
   prometheus:: import 'prometheus.libsonnet',
   sql:: import 'sql.libsonnet',

--- a/vendor/grafonnet/graph_panel.libsonnet
+++ b/vendor/grafonnet/graph_panel.libsonnet
@@ -207,8 +207,10 @@
     addAlert(
       name,
       executionErrorState='alerting',
+      forDuration='5m',
       frequency='60s',
       handler=1,
+      message='',
       noDataState='no_data',
       notifications=[],
     ):: self {
@@ -218,10 +220,12 @@
         name: name,
         conditions: it._conditions,
         executionErrorState: executionErrorState,
+        'for': forDuration,
         frequency: frequency,
         handler: handler,
         noDataState: noDataState,
         notifications: notifications,
+        message: message,
       },
       addCondition(condition):: self {
         _conditions+: [condition],


### PR DESCRIPTION
This PR update grafonnet dependency to the latest master.

Currently if one would like to vendor both kubernetes-grafana-mixin and kubernetes-mixin within the same jb repository, `jb install` command fails due to "diamond problem" with grafonnet dependency:

```
jb init && \
jb install https://github.com/kubernetes-monitoring/kubernetes-mixin@release-0.1 \
           https://github.com/povilasv/kubernetes-grafana-mixin@master
```

<details><summary>non-essential output</summary>

```
Cloning into 'vendor/.tmp/jsonnetpkg-kubernetes-mixin-release-0.1517939006'...
remote: Enumerating objects: 10, done.
remote: Counting objects: 100% (10/10), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 1403 (delta 2), reused 6 (delta 2), pack-reused 1393
Receiving objects: 100% (1403/1403), 5.16 MiB | 5.68 MiB/s, done.
Resolving deltas: 100% (890/890), done.
Branch 'release-0.1' set up to track remote branch 'release-0.1' from 'origin'.
Switched to a new branch 'release-0.1'
>>> Installed kubernetes-mixin version release-0.1
Cloning into 'vendor/.tmp/jsonnetpkg-grafonnet-master782008197'...
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 1421 (delta 0), reused 0 (delta 0), pack-reused 1416
Receiving objects: 100% (1421/1421), 821.67 KiB | 21.62 MiB/s, done.
Resolving deltas: 100% (825/825), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
>>> Installed grafonnet version master
Cloning into 'vendor/.tmp/jsonnetpkg-grafana-builder-master764584224'...
remote: Enumerating objects: 49, done.
remote: Counting objects: 100% (49/49), done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 5187 (delta 21), reused 34 (delta 14), pack-reused 5138
Receiving objects: 100% (5187/5187), 14.91 MiB | 19.60 MiB/s, done.
Resolving deltas: 100% (1618/1618), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
>>> Installed grafana-builder version master
Cloning into 'vendor/.tmp/jsonnetpkg-kubernetes-grafana-mixin-master579609599'...
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (106/106), done.
remote: Compressing objects: 100% (73/73), done.
remote: Total 106 (delta 50), reused 83 (delta 30), pack-reused 0
Receiving objects: 100% (106/106), 46.06 KiB | 11.52 MiB/s, done.
Resolving deltas: 100% (50/50), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
>>> Installed kubernetes-grafana-mixin version master
Cloning into 'vendor/.tmp/jsonnetpkg-grafonnet-11022f5e920ac1ea960556193e3f0ab57d70d7c5472946514'...
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 1421 (delta 0), reused 0 (delta 0), pack-reused 1416
Receiving objects: 100% (1421/1421), 821.67 KiB | 14.94 MiB/s, done.
Resolving deltas: 100% (825/825), done.
Note: checking out '11022f5e920ac1ea960556193e3f0ab57d70d7c5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

git checkout -b <new-branch-name>

HEAD is now at 11022f5 Merge pull request #113 from grafana/20190111_add_inputs_requires
>>> Installed grafonnet version 11022f5e920ac1ea960556193e3f0ab57d70d7c5
```

</details>

`jb: error: failed to install: failed to insert dependency to lock dependencies: multiple colliding versions specified for grafonnet: 3264a8ab6efa23d55da45ea3a3d3b39e86696c76 (from vendor/kubernetes-mixin/jsonnetfile.json) and 11022f5e920ac1ea960556193e3f0ab57d70d7c5 (from vendor/kubernetes-grafana-mixin/jsonnetfile.lock.json)`